### PR TITLE
removed warnings for deprecates

### DIFF
--- a/Sources/LoggerAPI/Logger.swift
+++ b/Sources/LoggerAPI/Logger.swift
@@ -35,31 +35,31 @@ public class Log {
     
 
     public static func verbose(msg: String, functionName: String = __FUNCTION__,
-        lineNum: Int = __LINE__, fileName: String = __FILE__ ) {
+        lineNum: Int = __LINE__, fileName: String = #file ) {
             logger?.log( .Verbose, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
     public class func info(msg: String, functionName: String = __FUNCTION__,
-        lineNum: Int = __LINE__, fileName: String = __FILE__) {
+        lineNum: Int = __LINE__, fileName: String = #file) {
             logger?.log( .Info, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
     public class func warning(msg: String, functionName: String = __FUNCTION__,
-        lineNum: Int = __LINE__, fileName: String = __FILE__) {
+        lineNum: Int = __LINE__, fileName: String = #file) {
             logger?.log( .Warning, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
     public class func error(msg: String, functionName: String = __FUNCTION__,
-        lineNum: Int = __LINE__, fileName: String = __FILE__) {
+        lineNum: Int = __LINE__, fileName: String = #file) {
             logger?.log( .Error, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
     public class func debug(msg: String, functionName: String = __FUNCTION__,
-        lineNum: Int = __LINE__, fileName: String = __FILE__) {
+        lineNum: Int = __LINE__, fileName: String = #file) {
             logger?.log( .Warning, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }

--- a/Sources/LoggerAPI/Logger.swift
+++ b/Sources/LoggerAPI/Logger.swift
@@ -35,31 +35,31 @@ public class Log {
     
 
     public static func verbose(msg: String, functionName: String = __FUNCTION__,
-        lineNum: Int = __LINE__, fileName: String = #file ) {
+        lineNum: Int = #line, fileName: String = #file ) {
             logger?.log( .Verbose, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
     public class func info(msg: String, functionName: String = __FUNCTION__,
-        lineNum: Int = __LINE__, fileName: String = #file) {
+        lineNum: Int = #line, fileName: String = #file) {
             logger?.log( .Info, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
     public class func warning(msg: String, functionName: String = __FUNCTION__,
-        lineNum: Int = __LINE__, fileName: String = #file) {
+        lineNum: Int = #line, fileName: String = #file) {
             logger?.log( .Warning, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
     public class func error(msg: String, functionName: String = __FUNCTION__,
-        lineNum: Int = __LINE__, fileName: String = #file) {
+        lineNum: Int = #line, fileName: String = #file) {
             logger?.log( .Error, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
     public class func debug(msg: String, functionName: String = __FUNCTION__,
-        lineNum: Int = __LINE__, fileName: String = #file) {
+        lineNum: Int = #line, fileName: String = #file) {
             logger?.log( .Warning, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }

--- a/Sources/LoggerAPI/Logger.swift
+++ b/Sources/LoggerAPI/Logger.swift
@@ -34,31 +34,31 @@ public class Log {
     public static var logger: Logger?
     
 
-    public static func verbose(msg: String, functionName: String = __FUNCTION__,
+    public static func verbose(msg: String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file ) {
             logger?.log( .Verbose, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
-    public class func info(msg: String, functionName: String = __FUNCTION__,
+    public class func info(msg: String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file) {
             logger?.log( .Info, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
-    public class func warning(msg: String, functionName: String = __FUNCTION__,
+    public class func warning(msg: String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file) {
             logger?.log( .Warning, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
-    public class func error(msg: String, functionName: String = __FUNCTION__,
+    public class func error(msg: String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file) {
             logger?.log( .Error, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)
     }
     
-    public class func debug(msg: String, functionName: String = __FUNCTION__,
+    public class func debug(msg: String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file) {
             logger?.log( .Warning, msg: msg,
                 functionName: functionName, lineNum: lineNum, fileName: fileName)


### PR DESCRIPTION
With reference to https://github.com/apple/swift-evolution/blob/master/proposals/0028-modernizing-debug-identifiers.md and to avoid warnings during compile I switched 

`__FILE__` references to the new `#file`
`__LINE__` references to the new `#line`
`__FUNCTION__` references to the new `#function`
