### PR TITLE
#25: Revert breakage from #24

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,9 +21,18 @@ import PackageDescription
 
 let package = Package(
     name: "LoggerAPI",
-    targets: [
-        .target(
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
             name: "LoggerAPI",
-            dependencies: []),
+            targets: ["LoggerAPI"]
+        )
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "LoggerAPI"
+        )
     ]
 )


### PR DESCRIPTION
Restores `Package.swift` to the same contents as `Package@swift-4.0.swift` prior to #24, reintroducing the `products` declaration which provides visibility of this module to dependents.

Resolves #25