### PR TITLE
Update API doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 <p align="center">
-    <a href="http://www.kitura.io/">
+    <a href="https://www.kitura.io/">
     <img src="https://img.shields.io/badge/docs-kitura.io-1FBCE4.svg" alt="Docs">
     </a>
     <a href="https://travis-ci.org/IBM-Swift/LoggerAPI">
@@ -22,10 +22,55 @@
 
 # LoggerAPI
 
-## Description
 A logger protocol that provides a common logging interface for different kinds of loggers. In addition, a class with a set of static functions for logging within your code is provided.
 
-Kitura uses this API throughout its implementation when logging.
+[Kitura](https://github.com/IBM-Swift/Kitura) uses this API throughout its implementation when logging.
+
+## Usage
+
+1. **Add dependencies**
+
+Add the `LoggerAPI` package to the dependencies within your application’s `Package.swift` file. Substitute `"x.x.x"` with the latest `LoggerAPI` [release](https://github.com/IBM-Swift/LoggerAPI/releases):
+
+```swift
+.package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "x.x.x")
+```
+Add `LoggerAPI` to your target's dependencies:
+```swift
+.target(name: "example", dependencies: ["LoggerAPI"]),
+```
+
+2. **Import package**
+
+```swift
+import LoggerAPI
+````
+
+3. **Log messages**
+
+Add log messages to your application:
+```swift
+Log.warning("This is a warning.")
+Log.error("This is an error.")
+```
+
+4. **Define a logger**
+
+You need to define a `logger` in order to output these messages:
+```swift
+Log.logger = ...
+```
+You can write your own logger implementation. In the case of Kitura, it defines
+`HeliumLogger` as the logger used by `LoggerAPI`. You can find out more about HeliumLogger [here](https://github.com/IBM-Swift/HeliumLogger/blob/master/README.md).
+
+## API documentation
+
+For more information visit our [API reference](http://ibm-swift.github.io/LoggerAPI/).
+
+## Community
+
+We love to talk server-side Swift, and Kitura. Join our [Slack](http://swift-at-ibm-slack.mybluemix.net/) to meet the team!
 
 ## License
-Apache 2.0
+
+This library is licensed under Apache 2.0. Full license text is available in [LICENSE](https://github.com/IBM-Swift/LoggerAPI/blob/master/LICENSE.txt).

--- a/Sources/LoggerAPI/Logger.swift
+++ b/Sources/LoggerAPI/Logger.swift
@@ -14,29 +14,9 @@
  * limitations under the License.
  **/
 
-/// The type of a particular log message. Passed with the message to be logged to the
-/// actual logger implementation. It is also used to enable filtering of the log based
-/// on minimal type to log.
-public enum LoggerMessageType: Int {
-    /// Log message type for logging entering into a function
-    case entry = 1
-    /// Log message type for logging exiting from a function
-    case exit = 2
-    /// Log message type for logging a debugging message
-    case debug = 3
-    /// Log message type for logging messages in verbose mode
-    case verbose = 4
-    /// Log message type for logging an informational message
-    case info = 5
-    /// Log message type for logging a warning message
-    case warning = 6
-    /// Log message type for logging an error message
-    case error = 7
-}
-
 /// Implement the `CustomStringConvertible` protocol for the `LoggerMessageType` enum
 extension LoggerMessageType: CustomStringConvertible {
-    /// Convert a `LoggerMessageType` into a pritable format
+    /// Convert a `LoggerMessageType` into a printable format.
     public var description: String {
         switch self {
         case .entry:
@@ -64,45 +44,45 @@ public protocol Logger {
     /// Output a logged message.
     ///
     /// - Parameter type: The type of the message (`LoggerMessageType`) being logged.
-    /// - Parameter msg: The message to be logged
+    /// - Parameter msg: The message to be logged.
     /// - Parameter functionName: The name of the function invoking the logger API.
     /// - Parameter lineNum: The line in the source code of the function invoking the
     ///                     logger API.
-    /// - Parameter fileName: The file of the source code of the function invoking the
+    /// - Parameter fileName: The file containing the source code of the function invoking the
     ///                      logger API.
     func log(_ type: LoggerMessageType, msg: String,
         functionName: String, lineNum: Int, fileName: String)
     
-    /// A function that will indicate if a message with a specified type (`LoggerMessageType`)
-    /// will be output in the log (i.e. will not be filtered out).
+    /// Indicates if a message with a specified type (`LoggerMessageType`) will be in the logger
+    /// output (i.e. will not be filtered out).
     ///
-    /// -Parameter type: The type of message that one wants to know if it will be output in the log.
+    /// - Parameter type: The type of message (`LoggerMessageType`).
     ///
-    /// - Returns: A Bool indicating whether, if true, or not a message of the specified type
-    ///           (`LoggerMessageType`) will be output.
+    /// - Returns: A Boolean indicating whether a message of the specified type
+    ///           (`LoggerMessageType`) will be in the logger output.
     func isLogging(_ level: LoggerMessageType) -> Bool
 
 }
 
-/// A class of static members used by anyone who wants to log mesages.
+/// A class of static members used by anyone who wants to log messages.
 public class Log {
 
     /// An instance of the logger. It should usually be the one and only reference
-    /// of the actual `Logger` protocol implementation in the system.
+    /// of the `Logger` protocol implementation in the system.
     public static var logger: Logger?
 
-    /// Log a log message for use when in verbose logging mode.
+    /// Log a message for use when in verbose logging mode.
     ///
-    /// - Parameter msg: The message to be logged
+    /// - Parameter msg: The message to be logged.
     /// - Parameter functionName: The name of the function invoking the logger API.
-    ///                          Defaults to the actual name of the function invoking
+    ///                          Defaults to the name of the function invoking
     ///                          this function.
     /// - Parameter lineNum: The line in the source code of the function invoking the
-    ///                     logger API. Defaults to the actual line of the actual
+    ///                     logger API. Defaults to the line of the
     ///                     function invoking this function.
-    /// - Parameter fileName: The file of the source code of the function invoking the
-    ///                      logger API. Defaults to the file of the actual function
-    ///                      invoking this function.
+    /// - Parameter fileName: The file containing the source code of the function invoking the
+    ///                      logger API. Defaults to the name of the file containing the function
+    ///                      which invokes this function.
     public static func verbose(_ msg: @autoclosure () -> String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file ) {
             if let logger = logger, logger.isLogging(.verbose) {
@@ -113,16 +93,16 @@ public class Log {
 
     /// Log an informational message.
     ///
-    /// - Parameter msg: The message to be logged
+    /// - Parameter msg: The message to be logged.
     /// - Parameter functionName: The name of the function invoking the logger API.
-    ///                          Defaults to the actual name of the function invoking
+    ///                          Defaults to the name of the function invoking
     ///                          this function.
     /// - Parameter lineNum: The line in the source code of the function invoking the
-    ///                     logger API. Defaults to the actual line of the actual
+    ///                     logger API. Defaults to the line of the
     ///                     function invoking this function.
-    /// - Parameter fileName: The file of the source code of the function invoking the
-    ///                      logger API. Defaults to the file of the actual function
-    ///                      invoking this function.
+    /// - Parameter fileName: The file containing the source code of the function invoking the
+    ///                      logger API. Defaults to the name of the file containing the function
+    ///                      which invokes this function.
     public class func info(_ msg: @autoclosure () -> String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file) {
             if let logger = logger, logger.isLogging(.info) {
@@ -133,16 +113,16 @@ public class Log {
 
     /// Log a warning message.
     ///
-    /// - Parameter msg: The message to be logged
+    /// - Parameter msg: The message to be logged.
     /// - Parameter functionName: The name of the function invoking the logger API.
-    ///                          Defaults to the actual name of the function invoking
+    ///                          Defaults to the name of the function invoking
     ///                          this function.
     /// - Parameter lineNum: The line in the source code of the function invoking the
-    ///                     logger API. Defaults to the actual line of the actual
+    ///                     logger API. Defaults to the line of the
     ///                     function invoking this function.
-    /// - Parameter fileName: The file of the source code of the function invoking the
-    ///                      logger API. Defaults to the file of the actual function
-    ///                      invoking this function.
+    /// - Parameter fileName: The file containing the source code of the function invoking the
+    ///                      logger API. Defaults to the name of the file containing the function
+    ///                      which invokes this function.
     public class func warning(_ msg: @autoclosure () -> String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file) {
             if let logger = logger, logger.isLogging(.warning) {
@@ -153,16 +133,16 @@ public class Log {
 
     /// Log an error message.
     ///
-    /// - Parameter msg: The message to be logged
+    /// - Parameter msg: The message to be logged.
     /// - Parameter functionName: The name of the function invoking the logger API.
-    ///                          Defaults to the actual name of the function invoking
+    ///                          Defaults to the name of the function invoking
     ///                          this function.
     /// - Parameter lineNum: The line in the source code of the function invoking the
-    ///                     logger API. Defaults to the actual line of the actual
+    ///                     logger API. Defaults to the line of the
     ///                     function invoking this function.
-    /// - Parameter fileName: The file of the source code of the function invoking the
-    ///                      logger API. Defaults to the file of the actual function
-    ///                      invoking this function.
+    /// - Parameter fileName: The file containing the source code of the function invoking the
+    ///                      logger API. Defaults to the name of the file containing the function
+    ///                      which invokes this function.
     public class func error(_ msg: @autoclosure () -> String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file) {
             if let logger = logger, logger.isLogging(.error) {
@@ -171,18 +151,18 @@ public class Log {
             }
     }
 
-    /// Log a debuging message.
+    /// Log a debugging message.
     ///
-    /// - Parameter msg: The message to be logged
+    /// - Parameter msg: The message to be logged.
     /// - Parameter functionName: The name of the function invoking the logger API.
-    ///                          Defaults to the actual name of the function invoking
+    ///                          Defaults to the name of the function invoking
     ///                          this function.
     /// - Parameter lineNum: The line in the source code of the function invoking the
-    ///                     logger API. Defaults to the actual line of the actual
+    ///                     logger API. Defaults to the line of the
     ///                     function invoking this function.
-    /// - Parameter fileName: The file of the source code of the function invoking the
-    ///                      logger API. Defaults to the file of the actual function
-    ///                      invoking this function.
+    /// - Parameter fileName: The file containing the source code of the function invoking the
+    ///                      logger API. Defaults to the name of the file containing the function
+    ///                      which invokes this function.
     public class func debug(_ msg: @autoclosure () -> String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file) {
             if let logger = logger, logger.isLogging(.debug) {
@@ -193,16 +173,16 @@ public class Log {
     
     /// Log a message when entering a function.
     ///
-    /// - Parameter msg: The message to be logged
+    /// - Parameter msg: The message to be logged.
     /// - Parameter functionName: The name of the function invoking the logger API.
-    ///                          Defaults to the actual name of the function invoking
+    ///                          Defaults to the name of the function invoking
     ///                          this function.
     /// - Parameter lineNum: The line in the source code of the function invoking the
-    ///                     logger API. Defaults to the actual line of the actual
+    ///                     logger API. Defaults to the line of the
     ///                     function invoking this function.
-    /// - Parameter fileName: The file of the source code of the function invoking the
-    ///                      logger API. Defaults to the file of the actual function
-    ///                      invoking this function.
+    /// - Parameter fileName: The file containing the source code of the function invoking the
+    ///                      logger API. Defaults to the name of the file containing the function
+    ///                      which invokes this function.
     public class func entry(_ msg: @autoclosure () -> String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file) {
             if let logger = logger, logger.isLogging(.entry) {
@@ -213,16 +193,16 @@ public class Log {
     
     /// Log a message when exiting a function.
     ///
-    /// - Parameter msg: The message to be logged
+    /// - Parameter msg: The message to be logged.
     /// - Parameter functionName: The name of the function invoking the logger API.
-    ///                          Defaults to the actual name of the function invoking
+    ///                          Defaults to the name of the function invoking
     ///                          this function.
     /// - Parameter lineNum: The line in the source code of the function invoking the
-    ///                     logger API. Defaults to the actual line of the actual
+    ///                     logger API. Defaults to the line of the
     ///                     function invoking this function.
-    /// - Parameter fileName: The file of the source code of the function invoking the
-    ///                      logger API. Defaults to the file of the actual function
-    ///                      invoking this function.
+    /// - Parameter fileName: The file containing the source code of the function invoking the
+    ///                      logger API. Defaults to the name of the file containing the function
+    ///                      which invokes this function.
     public class func exit(_ msg: @autoclosure () -> String, functionName: String = #function,
         lineNum: Int = #line, fileName: String = #file) {
             if let logger = logger, logger.isLogging(.exit) {
@@ -231,17 +211,37 @@ public class Log {
             }
     }
     
-    /// A function that will indicate if a message with a specified type (`LoggerMessageType`)
-    /// will be output in the log (i.e. will not be filtered out).
+    /// Indicates if a message with a specified type (`LoggerMessageType`) will be in the logger
+    /// output (i.e. will not be filtered out).
     ///
-    /// - Parameter type: The type of message that one wants to know if it will be output in the log.
+    /// - Parameter type: The type of message (`LoggerMessageType`).
     ///
-    /// - Returns: A Bool indicating whether, if true, or not a message of the specified type
-    ///           (`LoggerMessageType`) will be output.
+    /// - Returns: A Boolean indicating whether a message of the specified type
+    ///           (`LoggerMessageType`) will be in the logger output.
     public class func isLogging(_ level: LoggerMessageType) -> Bool {
         guard let logger = logger else {
             return false
         }
         return logger.isLogging(level)
     }
+}
+
+/// The type of a particular log message. It is passed with the message to be logged to the
+/// actual logger implementation. It is also used to enable filtering of the log based
+/// on the minimal type to log.
+public enum LoggerMessageType: Int {
+    /// Log message type for logging when entering into a function.
+    case entry = 1
+    /// Log message type for logging when exiting from a function.
+    case exit = 2
+    /// Log message type for logging a debugging message.
+    case debug = 3
+    /// Log message type for logging messages in verbose mode.
+    case verbose = 4
+    /// Log message type for logging an informational message.
+    case info = 5
+    /// Log message type for logging a warning message.
+    case warning = 6
+    /// Log message type for logging an error message.
+    case error = 7
 }


### PR DESCRIPTION
Updated API doc and README file to try and make it easier to use for new users.

(NB. I moved the enum to the bottom of the file as it was causing jazzy to output the license in the API docs!)