### PR TITLE
Update Podspec to LoggerAPI 1.8.0

### DIFF
--- a/LoggerAPI.podspec
+++ b/LoggerAPI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
-  s.name        = "IBMSwiftLoggerAPI"
-  s.version     = "1.7.3"
+  s.name        = "LoggerAPI"
+  s.version     = "1.8.0"
   s.summary     = "A logger protocol that provides a common logging interface for different kinds of loggers."
   s.homepage    = "https://github.com/IBM-Swift/LoggerAPI"
   s.license     = { :type => "Apache License, Version 2.0" }

--- a/LoggerAPI.podspec
+++ b/LoggerAPI.podspec
@@ -1,17 +1,12 @@
 Pod::Spec.new do |s|
-  s.name        = "LoggerAPI"
+  s.name        = "IBMSwiftLoggerAPI"
   s.version     = "1.7.3"
-  s.summary     = "Kitura uses this API throughout its implementation when logging"
+  s.summary     = "A logger protocol that provides a common logging interface for different kinds of loggers."
   s.homepage    = "https://github.com/IBM-Swift/LoggerAPI"
   s.license     = { :type => "Apache License, Version 2.0" }
   s.author     = "IBM"
   s.module_name  = 'LoggerAPI'
-
-  s.requires_arc = true
   s.ios.deployment_target = "10.0"
   s.source   = { :git => "https://github.com/IBM-Swift/LoggerAPI.git", :tag => s.version }
   s.source_files = "Sources/LoggerAPI/*.swift"
-  s.pod_target_xcconfig =  {
-        'SWIFT_VERSION' => '4.1',
-  }
 end


### PR DESCRIPTION
This PR updates the Podspec to IBMSwiftLoggerAPI. This provides a namespace for all the IBMSwift pods. It also Updates the pod description.