### PR TITLE
Add tvos, osx and watchos to podspec

### DIFF
--- a/LoggerAPI.podspec
+++ b/LoggerAPI.podspec
@@ -6,7 +6,10 @@ Pod::Spec.new do |s|
   s.license     = { :type => "Apache License, Version 2.0" }
   s.author     = "IBM"
   s.module_name  = 'LoggerAPI'
+  s.osx.deployment_target = "10.11"
   s.ios.deployment_target = "10.0"
+  s.tvos.deployment_target = "9.1"
+  s.watchos.deployment_target = "2.0"
   s.source   = { :git => "https://github.com/IBM-Swift/LoggerAPI.git", :tag => s.version }
   s.source_files = "Sources/LoggerAPI/*.swift"
 end


### PR DESCRIPTION
This pull request adds tvOS, osx and watchOS to the podspec file so that the pod can be used on those devices.
Since we don't use any platform features this can be added without any code changes.