### PR TITLE
Update podfile to point at 1.8.1 release

### DIFF
--- a/LoggerAPI.podspec
+++ b/LoggerAPI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "LoggerAPI"
-  s.version     = "1.8.0"
+  s.version     = "1.8.1"
   s.summary     = "A logger protocol that provides a common logging interface for different kinds of loggers."
   s.homepage    = "https://github.com/IBM-Swift/LoggerAPI"
   s.license     = { :type => "Apache License, Version 2.0" }


### PR DESCRIPTION
The pull request updates the podfile to point at the 1.8.1 release of LoggerAPI so that it can be picked up by cocoapods.