### PR TITLE
[Issue-61] Update deployment target versions and switch to SwiftlyLog…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
-.build
-build
+.DS_Store
 LoggerAPI.xcodeproj
+
+# Swift Package Manager
+#
+/Packages
+/Package.resolved
+/build
+/.build
+/.swiftpm

--- a/LoggerAPI.podspec
+++ b/LoggerAPI.podspec
@@ -1,17 +1,29 @@
 Pod::Spec.new do |s|
-  s.name        = "LoggerAPI"
-  s.version     = "2.0.0"
-  s.summary     = "A logger protocol that provides a common logging interface for different kinds of loggers."
-  s.homepage    = "https://github.com/Kitura/LoggerAPI"
-  s.license     = { :type => "Apache License, Version 2.0" }
-  s.author     = "IBM and the Kitura project authors"
-  s.module_name  = 'LoggerAPI'
-  s.swift_version = '5.1'
-  s.osx.deployment_target = "10.11"
-  s.ios.deployment_target = "10.0"
-  s.tvos.deployment_target = "9.1"
-  s.watchos.deployment_target = "2.0"
-  s.source   = { :git => "https://github.com/Kitura/LoggerAPI.git", :tag => s.version }
+
+  s.name              = "LoggerAPI"
+  s.module_name       = 'LoggerAPI'
+  s.version           = "2.0.0"
+  s.cocoapods_version = '~> 1.16'
+  s.summary           = "A logger protocol that provides a common logging interface for different kinds of loggers."
+  s.homepage          = "https://github.com/Kitura/LoggerAPI"
+  s.license           = {
+                          :type => "Apache License, Version 2.0"
+                        }
+  s.source            = {
+                          :git => "https://github.com/Kitura/LoggerAPI.git",
+                          :tag => s.version
+                        }
+
+  s.author            = "IBM and the Kitura project authors"
+
+  s.swift_version = '5.8'
+  
+  s.ios.deployment_target = "12.0"
+  s.osx.deployment_target = "11.0"
+  s.tvos.deployment_target = "12.0"
+  s.watchos.deployment_target = "8.0"
+  
   s.source_files = "Sources/**/*.swift"
-  s.dependency 'Logging', '~> 1.1'
+  
+  s.dependency 'SwiftlyLogging', '~> 1.6'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
…ging

* Update minimum deployment target versions to support current build tooling
* Update swift version to 5.8
* Updated to SwiftlyLogging (from Logging) to be able to pull in newer versions of that pod
  * Same pod, just published under a different name
  * Also updating from v. 1.1 to 1.6 minimum

Issue #61

Dependent on SwiftlyLogging being fully accessible via cocoapods' trunk - 
* https://cocoapods.org/pods/SwiftlyLogging
* https://github.com/CocoaPods/Specs/tree/master/Specs/7/6/8/SwiftlyLogging

(currently seems to be published...but `pod repo update` isn't pulling it down)