### PR TITLE
[Issue-61] Update version to 2.1.0

### DIFF
--- a/LoggerAPI.podspec
+++ b/LoggerAPI.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
   s.name              = "LoggerAPI"
   s.module_name       = 'LoggerAPI'
-  s.version           = "2.0.0"
+  s.version           = "2.1.0"
   s.cocoapods_version = '~> 1.16'
   s.summary           = "A logger protocol that provides a common logging interface for different kinds of loggers."
   s.homepage          = "https://github.com/Kitura/LoggerAPI"


### PR DESCRIPTION
Issue #61 

This is to bump the version to 2.1.0

### Release

https://github.com/Kitura/LoggerAPI/releases

### Dependencies
* Kitura/LoggerAPI#63
* Full publishing of `SwiftlyLogging` pod
  * https://cocoapods.org/pods/SwiftlyLogging
  * https://github.com/CocoaPods/Specs/tree/master/Specs/7/6/8/SwiftlyLogging
  * Currently seems to be published...but `pod repo update` isn't pulling it down